### PR TITLE
feat: Add Markdown (.md) file support for upload and processing

### DIFF
--- a/functions/src/assets.ts
+++ b/functions/src/assets.ts
@@ -122,7 +122,11 @@ export const onAssetUpload = functions
         model: "gemini-2.0-flash",
       });
 
-      const fileTypeHint = object.contentType === "application/pdf" ? "PDF文書" : "画像/ファイル";
+      const fileTypeHint = object.contentType === "application/pdf" 
+        ? "PDF文書" 
+        : (object.contentType === "text/markdown" || object.contentType === "text/x-markdown" || object.name?.endsWith(".md"))
+        ? "Markdown文書"
+        : "画像/ファイル";
       const analysisPrompt = `
 この${fileTypeHint}を詳細に分析し、以下の情報をJSON形式で出力してください。
 必ず全てのフィールドに値を入れてください:
@@ -140,13 +144,16 @@ ${visionAnalysis.labels.length > 0 ? `検出されたラベル: ${visionAnalysis
 
       const parts: any[] = [{ text: analysisPrompt }];
 
-      // 画像またはPDFの場合、インラインBase64データとしてGeminiに送信
-      // （GCS URIだとVertex AIサービスエージェントの権限問題が発生するため）
-      if (object.contentType?.startsWith("image/") || object.contentType === "application/pdf") {
+      // 画像、PDF、Markdownの場合、インラインBase64データとしてGeminiに送信
+      // (GCS URIだとVertex AIサービスエージェントの権限問題が発生するため)
+      const isMarkdown = object.contentType === "text/markdown" || object.contentType === "text/x-markdown" || object.name?.endsWith(".md");
+      if (object.contentType?.startsWith("image/") || object.contentType === "application/pdf" || isMarkdown) {
+        // Markdownの場合はmimeTypeをtext/markdownに正規化
+        const mimeType = isMarkdown ? "text/markdown" : object.contentType;
         parts.push({
           inlineData: {
             data: fileBase64,
-            mimeType: object.contentType,
+            mimeType: mimeType,
           },
         });
       }

--- a/functions/src/brand-extraction.ts
+++ b/functions/src/brand-extraction.ts
@@ -353,11 +353,15 @@ export const extractBrandFromFile = functions
       const isImage = fileType.startsWith("image/");
       const isPdf =
         fileType === "application/pdf" || fileName.endsWith(".pdf");
+      const isMarkdown =
+        fileType === "text/markdown" ||
+        fileType === "text/x-markdown" ||
+        fileName.endsWith(".md");
 
-      if (!isImage && !isPdf) {
+      if (!isImage && !isPdf && !isMarkdown) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          "対応形式: PDF, 画像（JPG, PNG, WebP）"
+          "対応形式: PDF, 画像(JPG, PNG, WebP), Markdown"
         );
       }
 

--- a/src/app/(dashboard)/assets/page.tsx
+++ b/src/app/(dashboard)/assets/page.tsx
@@ -137,7 +137,8 @@ export default function AssetsPage() {
     const matchesType = filterType === "all" ||
       (filterType === "image" && asset.fileType.startsWith("image/")) ||
       (filterType === "pdf" && (asset.fileType === "application/pdf" || asset.fileName.endsWith(".pdf"))) ||
-      (filterType === "other" && !asset.fileType.startsWith("image/") && asset.fileType !== "application/pdf");
+      (filterType === "markdown" && (asset.fileType === "text/markdown" || asset.fileType === "text/x-markdown" || asset.fileName.endsWith(".md"))) ||
+      (filterType === "other" && !asset.fileType.startsWith("image/") && asset.fileType !== "application/pdf" && asset.fileType !== "text/markdown" && asset.fileType !== "text/x-markdown" && !asset.fileName.endsWith(".md"));
 
     return matchesSearch && matchesType;
   });
@@ -171,7 +172,7 @@ export default function AssetsPage() {
                 <Input
                   id="file"
                   type="file"
-                  accept="image/*,.pdf,.txt,.doc,.docx"
+                  accept="image/*,.pdf,.txt,.doc,.docx,.md"
                   onChange={handleFileChange}
                 />
               </div>
@@ -269,6 +270,7 @@ export default function AssetsPage() {
                   <SelectItem value="all">すべて ({assets.length})</SelectItem>
                   <SelectItem value="image">画像</SelectItem>
                   <SelectItem value="pdf">PDF</SelectItem>
+                  <SelectItem value="markdown">Markdown</SelectItem>
                   <SelectItem value="other">その他</SelectItem>
                 </SelectContent>
               </Select>

--- a/src/components/features/brand-extraction/BrandExtractionDialog.tsx
+++ b/src/components/features/brand-extraction/BrandExtractionDialog.tsx
@@ -25,7 +25,7 @@ interface BrandExtractionDialogProps {
   onComplete: (result: BrandExtractionResult) => void;
 }
 
-const ACCEPTED_FILE_TYPES = ".pdf,.jpg,.jpeg,.png,.webp";
+const ACCEPTED_FILE_TYPES = ".pdf,.jpg,.jpeg,.png,.webp,.md";
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
 
 export function BrandExtractionDialog({
@@ -259,7 +259,7 @@ export function BrandExtractionDialog({
                       ドラッグ＆ドロップ、またはクリック
                     </p>
                     <p className="text-xs text-muted-foreground mt-1">
-                      PDF / JPG / PNG / WebP（最大20MB）
+                      PDF / JPG / PNG / WebP / MD(最大20MB)
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
## 概要
このPRは、ファイルアップロード/処理機能に Markdown (.md) ファイルのサポートを追加します。

## 変更内容

### フロントエンド
- **assets/page.tsx**: アップロード時のファイル受け入れリストに `.md` を追加
- **BrandExtractionDialog.tsx**: ブランド抽出ダイアログで `.md` ファイルを受け入れるように変更
- **assets/page.tsx**: フィルタータイプに「Markdown」を追加し、Markdown ファイルでフィルタリング可能に

### バックエンド
- **brand-extraction.ts**: Markdown ファイルの判定とサポートを追加
  - `text/markdown`, `text/x-markdown` MIME タイプと `.md` 拡張子に対応
  - エラーメッセージを更新して Markdown サポートを明記
- **assets.ts**: Markdown ファイルの分析対応を追加
  - ファイルタイプヒントに「Markdown文書」を追加
  - Markdown ファイルを Base64 データとして Gemini に送信
  - MIME タイプを `text/markdown` に正規化

## テスト
- 構文チェック完了
- 変更箇所のコードレビュー完了