### PR TITLE
feat: ブランドメンバー管理機能を実装

### DIFF
--- a/functions/src/brand-members.ts
+++ b/functions/src/brand-members.ts
@@ -1,0 +1,331 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { verifyBrandMember } from "./utils";
+
+const db = admin.firestore();
+
+/**
+ * ブランドメンバーを招待する
+ * 
+ * @param brandId - ブランドID
+ * @param email - 招待するユーザーのメールアドレス
+ * @param role - 付与するロール (OWNER | ADMIN | MEMBER)
+ * 
+ * @returns 招待されたメンバーの情報
+ */
+export const inviteBrandMember = functions
+  .region("asia-northeast1")
+  .https.onCall(async (data, context) => {
+    // 認証チェック
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "認証が必要です"
+      );
+    }
+
+    const { brandId, email, role } = data;
+
+    // パラメータバリデーション
+    if (!brandId || !email || !role) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "brandId, email, roleは必須です"
+      );
+    }
+
+    // ロールのバリデーション
+    const validRoles = ["OWNER", "ADMIN", "MEMBER"];
+    if (!validRoles.includes(role)) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "roleはOWNER, ADMIN, MEMBERのいずれかである必要があります"
+      );
+    }
+
+    // 招待者の権限チェック（OWNER または ADMIN のみ招待可能）
+    const inviterMember = await verifyBrandMember(brandId, context.auth.uid);
+    if (inviterMember.role !== "OWNER" && inviterMember.role !== "ADMIN") {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "メンバーを招待する権限がありません"
+      );
+    }
+
+    // OWNERロールの付与はOWNERのみ可能
+    if (role === "OWNER" && inviterMember.role !== "OWNER") {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "OWNERロールを付与する権限がありません"
+      );
+    }
+
+    // 招待するユーザーを検索
+    const usersQuery = await db
+      .collection("users")
+      .where("email", "==", email)
+      .limit(1)
+      .get();
+
+    if (usersQuery.empty) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "指定されたメールアドレスのユーザーが見つかりません"
+      );
+    }
+
+    const userDoc = usersQuery.docs[0];
+    const userId = userDoc.id;
+    const userData = userDoc.data();
+
+    // 既にメンバーかチェック
+    const memberId = `${brandId}_${userId}`;
+    const existingMember = await db
+      .collection("brandMembers")
+      .doc(memberId)
+      .get();
+
+    if (existingMember.exists) {
+      throw new functions.https.HttpsError(
+        "already-exists",
+        "このユーザーは既にブランドメンバーです"
+      );
+    }
+
+    // メンバーを追加
+    const memberData = {
+      brandId,
+      userId,
+      role,
+      joinedAt: admin.firestore.FieldValue.serverTimestamp(),
+    };
+
+    await db.collection("brandMembers").doc(memberId).set(memberData);
+
+    return {
+      id: memberId,
+      ...memberData,
+      user: {
+        id: userId,
+        email: userData.email,
+        displayName: userData.displayName || null,
+        photoURL: userData.photoURL || null,
+      },
+    };
+  });
+
+/**
+ * ブランドメンバーのロールを変更する
+ * 
+ * @param memberId - メンバーID (${brandId}_${userId})
+ * @param role - 新しいロール (OWNER | ADMIN | MEMBER)
+ * 
+ * @returns 更新されたメンバーの情報
+ */
+export const updateBrandMemberRole = functions
+  .region("asia-northeast1")
+  .https.onCall(async (data, context) => {
+    // 認証チェック
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "認証が必要です"
+      );
+    }
+
+    const { memberId, role } = data;
+
+    // パラメータバリデーション
+    if (!memberId || !role) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "memberId, roleは必須です"
+      );
+    }
+
+    // ロールのバリデーション
+    const validRoles = ["OWNER", "ADMIN", "MEMBER"];
+    if (!validRoles.includes(role)) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "roleはOWNER, ADMIN, MEMBERのいずれかである必要があります"
+      );
+    }
+
+    // メンバー情報を取得
+    const memberDoc = await db.collection("brandMembers").doc(memberId).get();
+    if (!memberDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "指定されたメンバーが見つかりません"
+      );
+    }
+
+    const memberData = memberDoc.data()!;
+    const brandId = memberData.brandId;
+
+    // 実行者の権限チェック（OWNER のみロール変更可能）
+    const executorMember = await verifyBrandMember(brandId, context.auth.uid);
+    if (executorMember.role !== "OWNER") {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "メンバーのロールを変更する権限がありません"
+      );
+    }
+
+    // 自分自身のロールは変更できない
+    if (memberData.userId === context.auth.uid) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "自分自身のロールは変更できません"
+      );
+    }
+
+    // ロールを更新
+    await db.collection("brandMembers").doc(memberId).update({
+      role,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    return {
+      id: memberId,
+      ...memberData,
+      role,
+    };
+  });
+
+/**
+ * ブランドメンバーを削除する
+ * 
+ * @param memberId - メンバーID (${brandId}_${userId})
+ * 
+ * @returns 削除されたメンバーのID
+ */
+export const removeBrandMember = functions
+  .region("asia-northeast1")
+  .https.onCall(async (data, context) => {
+    // 認証チェック
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "認証が必要です"
+      );
+    }
+
+    const { memberId } = data;
+
+    // パラメータバリデーション
+    if (!memberId) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "memberIdは必須です"
+      );
+    }
+
+    // メンバー情報を取得
+    const memberDoc = await db.collection("brandMembers").doc(memberId).get();
+    if (!memberDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "指定されたメンバーが見つかりません"
+      );
+    }
+
+    const memberData = memberDoc.data()!;
+    const brandId = memberData.brandId;
+
+    // 実行者の権限チェック（OWNER または ADMIN のみ削除可能）
+    const executorMember = await verifyBrandMember(brandId, context.auth.uid);
+    if (executorMember.role !== "OWNER" && executorMember.role !== "ADMIN") {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "メンバーを削除する権限がありません"
+      );
+    }
+
+    // OWNERは削除できない
+    if (memberData.role === "OWNER") {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "OWNERロールのメンバーは削除できません"
+      );
+    }
+
+    // ADMINの削除はOWNERのみ可能
+    if (memberData.role === "ADMIN" && executorMember.role !== "OWNER") {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "ADMINロールのメンバーを削除する権限がありません"
+      );
+    }
+
+    // メンバーを削除
+    await db.collection("brandMembers").doc(memberId).delete();
+
+    return {
+      id: memberId,
+      deleted: true,
+    };
+  });
+
+/**
+ * ブランドメンバー一覧を取得する（ユーザー情報付き）
+ * 
+ * @param brandId - ブランドID
+ * 
+ * @returns メンバー一覧（ユーザー情報を含む）
+ */
+export const getBrandMembersWithUsers = functions
+  .region("asia-northeast1")
+  .https.onCall(async (data, context) => {
+    // 認証チェック
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "認証が必要です"
+      );
+    }
+
+    const { brandId } = data;
+
+    // パラメータバリデーション
+    if (!brandId) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "brandIdは必須です"
+      );
+    }
+
+    // アクセス権限チェック
+    await verifyBrandMember(brandId, context.auth.uid);
+
+    // メンバー一覧を取得
+    const membersSnapshot = await db
+      .collection("brandMembers")
+      .where("brandId", "==", brandId)
+      .get();
+
+    // ユーザー情報を取得して結合
+    const members = await Promise.all(
+      membersSnapshot.docs.map(async (doc) => {
+        const memberData = doc.data();
+        const userDoc = await db.collection("users").doc(memberData.userId).get();
+        const userData = userDoc.exists ? userDoc.data() : null;
+
+        return {
+          id: doc.id,
+          ...memberData,
+          user: userData
+            ? {
+                id: userDoc.id,
+                email: userData.email,
+                displayName: userData.displayName || null,
+                photoURL: userData.photoURL || null,
+              }
+            : null,
+        };
+      })
+    );
+
+    return members;
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -22,3 +22,11 @@ export { generatePresentation } from "./presentations";
 
 // 印刷関連関数（Epson Connect）
 export { printCreative, saveEpsonSettings, getEpsonSettings } from "./printing";
+
+// ブランドメンバー管理関数
+export {
+  inviteBrandMember,
+  updateBrandMemberRole,
+  removeBrandMember,
+  getBrandMembersWithUsers,
+} from "./brand-members";

--- a/src/app/(dashboard)/brands/[brandId]/settings/page.tsx
+++ b/src/app/(dashboard)/brands/[brandId]/settings/page.tsx
@@ -39,6 +39,7 @@ import {
 import { toast } from "sonner";
 import { uploadLogo } from "@/lib/firebase/storage";
 import { updateBrand } from "@/lib/firebase/firestore";
+import { BrandMembersCard } from "@/components/features/brand-members/BrandMembersCard";
 
 interface BrandSettingsPageProps {
   params: Promise<{ brandId: string }>;
@@ -265,6 +266,8 @@ export default function BrandSettingsPage({ params }: BrandSettingsPageProps) {
             </Button>
           </CardContent>
         </Card>
+
+        <BrandMembersCard brandId={brandId} />
 
         <Card className="border-destructive/50">
           <CardHeader>

--- a/src/components/features/brand-members/BrandMembersCard.tsx
+++ b/src/components/features/brand-members/BrandMembersCard.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useAuthContext } from "@/components/providers";
+import { getFunctions, httpsCallable } from "firebase/functions";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { UserPlus, Loader2, Mail, Trash2, Shield } from "lucide-react";
+import { toast } from "sonner";
+import type { BrandRole } from "@/types";
+
+interface BrandMember {
+  id: string;
+  brandId: string;
+  userId: string;
+  role: BrandRole;
+  joinedAt: any;
+  user: {
+    id: string;
+    email: string;
+    displayName: string | null;
+    photoURL: string | null;
+  } | null;
+}
+
+interface BrandMembersCardProps {
+  brandId: string;
+}
+
+const roleLabels: Record<BrandRole, string> = {
+  OWNER: "オーナー",
+  ADMIN: "管理者",
+  MEMBER: "メンバー",
+};
+
+const roleColors: Record<BrandRole, string> = {
+  OWNER: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+  ADMIN: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  MEMBER: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
+};
+
+export function BrandMembersCard({ brandId }: BrandMembersCardProps) {
+  const { user } = useAuthContext();
+  const [members, setMembers] = useState<BrandMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<BrandRole>("MEMBER");
+  const [inviting, setInviting] = useState(false);
+  const [currentUserRole, setCurrentUserRole] = useState<BrandRole | null>(null);
+
+  const functions = getFunctions(undefined, "asia-northeast1");
+
+  useEffect(() => {
+    loadMembers();
+  }, [brandId]);
+
+  const loadMembers = async () => {
+    setLoading(true);
+    try {
+      const getBrandMembersWithUsers = httpsCallable<
+        { brandId: string },
+        BrandMember[]
+      >(functions, "getBrandMembersWithUsers");
+
+      const result = await getBrandMembersWithUsers({ brandId });
+      setMembers(result.data);
+
+      // 現在のユーザーのロールを取得
+      const currentMember = result.data.find((m) => m.userId === user?.id);
+      setCurrentUserRole(currentMember?.role || null);
+    } catch (error: any) {
+      console.error("Failed to load members:", error);
+      toast.error("メンバー一覧の取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInvite = async () => {
+    if (!inviteEmail.trim()) {
+      toast.error("メールアドレスを入力してください");
+      return;
+    }
+
+    setInviting(true);
+    try {
+      const inviteBrandMember = httpsCallable<
+        { brandId: string; email: string; role: BrandRole },
+        BrandMember
+      >(functions, "inviteBrandMember");
+
+      await inviteBrandMember({
+        brandId,
+        email: inviteEmail.trim(),
+        role: inviteRole,
+      });
+
+      toast.success("メンバーを招待しました");
+      setInviteDialogOpen(false);
+      setInviteEmail("");
+      setInviteRole("MEMBER");
+      loadMembers();
+    } catch (error: any) {
+      console.error("Failed to invite member:", error);
+      const message = error.message || "メンバーの招待に失敗しました";
+      toast.error(message);
+    } finally {
+      setInviting(false);
+    }
+  };
+
+  const handleRoleChange = async (memberId: string, newRole: BrandRole) => {
+    try {
+      const updateBrandMemberRole = httpsCallable<
+        { memberId: string; role: BrandRole },
+        any
+      >(functions, "updateBrandMemberRole");
+
+      await updateBrandMemberRole({ memberId, role: newRole });
+      toast.success("ロールを変更しました");
+      loadMembers();
+    } catch (error: any) {
+      console.error("Failed to update role:", error);
+      const message = error.message || "ロールの変更に失敗しました";
+      toast.error(message);
+    }
+  };
+
+  const handleRemoveMember = async (memberId: string) => {
+    try {
+      const removeBrandMember = httpsCallable<{ memberId: string }, any>(
+        functions,
+        "removeBrandMember"
+      );
+
+      await removeBrandMember({ memberId });
+      toast.success("メンバーを削除しました");
+      loadMembers();
+    } catch (error: any) {
+      console.error("Failed to remove member:", error);
+      const message = error.message || "メンバーの削除に失敗しました";
+      toast.error(message);
+    }
+  };
+
+  const canInvite = currentUserRole === "OWNER" || currentUserRole === "ADMIN";
+  const canChangeRole = currentUserRole === "OWNER";
+  const canRemove = currentUserRole === "OWNER" || currentUserRole === "ADMIN";
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base font-medium">メンバー管理</CardTitle>
+          <CardDescription>
+            ブランドメンバーの招待と権限管理
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-base font-medium">メンバー管理</CardTitle>
+            <CardDescription>
+              ブランドメンバーの招待と権限管理
+            </CardDescription>
+          </div>
+          {canInvite && (
+            <Dialog open={inviteDialogOpen} onOpenChange={setInviteDialogOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm">
+                  <UserPlus className="mr-2 h-4 w-4" />
+                  メンバーを招待
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>メンバーを招待</DialogTitle>
+                  <DialogDescription>
+                    招待するユーザーのメールアドレスとロールを指定してください
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="email">メールアドレス</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      placeholder="user@example.com"
+                      value={inviteEmail}
+                      onChange={(e) => setInviteEmail(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="role">ロール</Label>
+                    <Select
+                      value={inviteRole}
+                      onValueChange={(value) => setInviteRole(value as BrandRole)}
+                    >
+                      <SelectTrigger id="role">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="MEMBER">メンバー</SelectItem>
+                        <SelectItem value="ADMIN">管理者</SelectItem>
+                        {currentUserRole === "OWNER" && (
+                          <SelectItem value="OWNER">オーナー</SelectItem>
+                        )}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {inviteRole === "OWNER" && "すべての権限を持ちます"}
+                      {inviteRole === "ADMIN" && "メンバーの招待と削除ができます"}
+                      {inviteRole === "MEMBER" && "閲覧と編集ができます"}
+                    </p>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    onClick={() => setInviteDialogOpen(false)}
+                    disabled={inviting}
+                  >
+                    キャンセル
+                  </Button>
+                  <Button onClick={handleInvite} disabled={inviting}>
+                    {inviting ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        招待中...
+                      </>
+                    ) : (
+                      "招待する"
+                    )}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {members.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              メンバーがいません
+            </div>
+          ) : (
+            members.map((member) => (
+              <div
+                key={member.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <Avatar>
+                    <AvatarImage
+                      src={member.user?.photoURL || undefined}
+                      alt={member.user?.displayName || member.user?.email || ""}
+                    />
+                    <AvatarFallback>
+                      {member.user?.displayName?.[0]?.toUpperCase() ||
+                        member.user?.email?.[0]?.toUpperCase() ||
+                        "?"}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <div className="font-medium">
+                      {member.user?.displayName || member.user?.email || "Unknown"}
+                    </div>
+                    <div className="text-sm text-muted-foreground flex items-center gap-2">
+                      <Mail className="h-3 w-3" />
+                      {member.user?.email}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {canChangeRole && member.userId !== user?.id ? (
+                    <Select
+                      value={member.role}
+                      onValueChange={(value) =>
+                        handleRoleChange(member.id, value as BrandRole)
+                      }
+                    >
+                      <SelectTrigger className="w-32">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="MEMBER">メンバー</SelectItem>
+                        <SelectItem value="ADMIN">管理者</SelectItem>
+                        <SelectItem value="OWNER">オーナー</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <Badge className={roleColors[member.role]}>
+                      <Shield className="mr-1 h-3 w-3" />
+                      {roleLabels[member.role]}
+                    </Badge>
+                  )}
+                  {canRemove &&
+                    member.role !== "OWNER" &&
+                    member.userId !== user?.id && (
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button variant="ghost" size="icon">
+                            <Trash2 className="h-4 w-4 text-destructive" />
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>メンバーを削除しますか？</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              {member.user?.displayName || member.user?.email}
+                              をブランドメンバーから削除します。この操作は取り消すことができません。
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogAction
+                              onClick={() => handleRemoveMember(member.id)}
+                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                            >
+                              削除する
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## 概要
ブランドメンバー管理機能を実装し、複数のユーザーが協力してブランドを管理できるようにしました。

## 実装内容

### Cloud Functions
- `inviteBrandMember`: メールアドレスでユーザーを検索してブランドメンバーに招待
- `updateBrandMemberRole`: メンバーのロールを変更（OWNER/ADMIN/MEMBER）
- `removeBrandMember`: メンバーをブランドから削除
- `getBrandMembersWithUsers`: メンバー一覧をユーザー情報付きで取得

### フロントエンド
- `BrandMembersCard`: メンバー管理UIコンポーネント
- ブランド設定ページにメンバー管理セクションを追加
- メンバー招待ダイアログ
- ロール変更セレクト
- メンバー削除確認ダイアログ

### 権限管理
- **OWNER**: すべての権限（ロール変更、メンバー削除）
- **ADMIN**: メンバーの招待と削除（OWNERロールの付与・ADMINの削除は不可）
- **MEMBER**: 閲覧と編集のみ

### セキュリティ
- 各Cloud Functionで認証チェック
- ロールベースのアクセス制御
- OWNERロールの保護（削除不可、OWNER以外は付与不可）
- 自分自身のロール変更を禁止

## テスト
- TypeScriptビルド成功
- 型チェック成功

## 変更ファイル
- `functions/src/brand-members.ts`: Cloud Functions実装
- `functions/src/index.ts`: 関数エクスポート
- `src/components/features/brand-members/BrandMembersCard.tsx`: メンバー管理UIコンポーネント
- `src/app/(dashboard)/brands/[brandId]/settings/page.tsx`: 設定ページに統合