### PR TITLE
feat: クリエイティブフィードバック機能を追加

### DIFF
--- a/FEEDBACK_FEATURE_DESIGN.md
+++ b/FEEDBACK_FEATURE_DESIGN.md
@@ -1,0 +1,98 @@
+# クリエイティブフィードバック機能 設計書
+
+## 概要
+生成されたクリエイティブに対して、チャット形式でフィードバックを行い、AIが改善案を提示・適用できる機能を追加する。
+
+## 機能要件
+
+### 1. フィードバックチャット
+- 各クリエイティブカードに「フィードバック」ボタンを追加
+- ダイアログまたはサイドパネルでチャット形式のUIを表示
+- ユーザーがフィードバックを入力すると、AIが改善案を生成
+- 改善案を承認すると、クリエイティブの内容が更新される
+
+### 2. データ構造
+
+#### Firestore コレクション: `creativeFeedbacks`
+```typescript
+interface CreativeFeedback {
+  id: string;
+  creativeId: string;
+  brandId: string;
+  userId: string;
+  messages: FeedbackMessage[];
+  status: "active" | "resolved";
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+interface FeedbackMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Timestamp;
+  // assistantの場合のみ
+  improvedContent?: string;
+  appliedAt?: Timestamp;
+}
+```
+
+### 3. Cloud Functions
+
+#### `sendCreativeFeedback`
+- リクエスト: `{ creativeId, feedbackText }`
+- 処理:
+  1. クリエイティブとブランドDNAを取得
+  2. フィードバック履歴を取得
+  3. Gemini APIで改善案を生成
+  4. Firestoreに保存して返却
+- レスポンス: `{ success, message, improvedContent }`
+
+#### `applyCreativeImprovement`
+- リクエスト: `{ creativeId, messageId }`
+- 処理:
+  1. フィードバックメッセージから改善内容を取得
+  2. クリエイティブの内容を更新
+  3. 適用日時を記録
+- レスポンス: `{ success, message }`
+
+### 4. フロントエンド実装
+
+#### コンポーネント構成
+```
+CreativeFeedbackDialog
+├── FeedbackChatArea (メッセージ一覧)
+│   ├── UserMessage
+│   └── AssistantMessage (改善案 + 適用ボタン)
+└── FeedbackInput (入力フォーム)
+```
+
+#### UI/UX
+- クリエイティブカードに「💬 フィードバック」ボタン追加
+- ダイアログで全画面表示
+- 左側: 元のクリエイティブ内容
+- 右側: チャット形式のフィードバックエリア
+- 改善案には「✓ この改善を適用」ボタン
+
+## 技術スタック
+- フロントエンド: React, shadcn/ui Dialog, Textarea
+- バックエンド: Cloud Functions, Vertex AI (Gemini 2.0 Flash)
+- データベース: Cloud Firestore
+
+## 実装手順
+1. Firestore型定義を追加 (`src/types/index.ts`)
+2. Cloud Functions実装 (`functions/src/feedback.ts`)
+3. Firebase Functions呼び出し関数追加 (`src/lib/firebase/functions.ts`)
+4. Firestore操作関数追加 (`src/lib/firebase/firestore.ts`)
+5. フィードバックUIコンポーネント作成 (`src/components/features/creative-feedback/`)
+6. クリエイティブページに統合 (`src/app/(dashboard)/creatives/page.tsx`)
+
+## セキュリティ
+- フィードバック送信時にブランドメンバーシップを検証
+- 改善適用時にも権限チェック
+- Firestore Rulesでアクセス制御
+
+## 今後の拡張
+- フィードバック履歴の検索・フィルタリング
+- 複数の改善案を提示
+- フィードバックのエクスポート機能

--- a/firestore.rules
+++ b/firestore.rules
@@ -55,8 +55,16 @@ service cloud.firestore {
       allow write: if isBrandOwnerOrAdmin(brandId);
     }
 
-    // クリエイティブ（list操作ではexists()が使えないためget/listを分離）
+    // クリエイティブ(list操作ではexists()が使えないためget/listを分離)
     match /creatives/{creativeId} {
+      allow get: if isAuthenticated() && isBrandMember(resource.data.brandId);
+      allow list: if isAuthenticated();
+      allow create: if isAuthenticated();
+      allow update, delete: if isAuthenticated() && isBrandMember(resource.data.brandId);
+    }
+
+    // クリエイティブフィードバック
+    match /creativeFeedbacks/{feedbackId} {
       allow get: if isAuthenticated() && isBrandMember(resource.data.brandId);
       allow list: if isAuthenticated();
       allow create: if isAuthenticated();

--- a/functions/src/feedback.ts
+++ b/functions/src/feedback.ts
@@ -1,0 +1,407 @@
+import * as functions from "firebase-functions/v2";
+import * as admin from "firebase-admin";
+import { VertexAI } from "@google-cloud/vertexai";
+import { verifyBrandMember } from "./utils";
+
+const db = admin.firestore();
+
+const PROJECT_ID = process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || "aiopress";
+const LOCATION = process.env.GOOGLE_CLOUD_LOCATION || "asia-northeast1";
+
+const vertexAI = new VertexAI({
+  project: PROJECT_ID,
+  location: LOCATION,
+});
+
+/**
+ * ブランドDNA情報を含むシステム命令を構築
+ */
+function buildBrandContext(brand: any, designSystem: any): string {
+  const brandDNA = designSystem?.brandDNA || {};
+  return `
+【ブランドDNA】
+- ブランド名: ${brand?.name || "不明"}
+- 説明: ${brand?.description || "なし"}
+- ミッション: ${brandDNA.mission || "未設定"}
+- ビジョン: ${brandDNA.vision || "未設定"}
+- 提供価値: ${brandDNA.valueProposition || "未設定"}
+- パーソナリティ: ${brandDNA.personality || "未設定"}
+- トーン＆マナー: ${brandDNA.tone || "未設定"}
+
+【ブランド特性】
+- 価値観: ${designSystem?.brandValues?.join("、") || "なし"}
+- ボイストーン: フォーマリティ=${designSystem?.voiceTone?.formality || "neutral"}, 熱意=${designSystem?.voiceTone?.enthusiasm || "medium"}, 共感性=${designSystem?.voiceTone?.empathy || "medium"}
+- ターゲット: ${designSystem?.targetAudience || "一般"}
+- キーワード: ${designSystem?.keywords?.join("、") || "なし"}
+- ブランドカラー: プライマリ=${designSystem?.colors?.primary || "#000"}, セカンダリ=${designSystem?.colors?.secondary || "#000"}, アクセント=${designSystem?.colors?.accent || "#000"}
+`.trim();
+}
+
+/**
+ * クリエイティブフィードバックを送信し、改善案を生成
+ */
+export const sendCreativeFeedback = functions.https.onCall(
+  {
+    region: LOCATION,
+    cors: true,
+  },
+  async (request) => {
+    const uid = request.auth?.uid;
+    if (!uid) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "認証が必要です"
+      );
+    }
+
+    const { creativeId, feedbackText } = request.data;
+
+    if (!creativeId || !feedbackText?.trim()) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "creativeIdとfeedbackTextは必須です"
+      );
+    }
+
+    try {
+      // クリエイティブを取得
+      const creativeDoc = await db.collection("creatives").doc(creativeId).get();
+      if (!creativeDoc.exists) {
+        throw new functions.https.HttpsError("not-found", "クリエイティブが見つかりません");
+      }
+
+      const creative = creativeDoc.data();
+      const brandId = creative?.brandId;
+
+      if (!brandId) {
+        throw new functions.https.HttpsError("invalid-argument", "ブランドIDが不正です");
+      }
+
+      // ブランドメンバーシップを検証
+      await verifyBrandMember(brandId, uid);
+
+      // ブランドとデザインシステムを取得
+      const [brandDoc, designSystemDoc] = await Promise.all([
+        db.collection("brands").doc(brandId).get(),
+        db.collection("designSystems").doc(brandId).get(),
+      ]);
+
+      const brand = brandDoc.data();
+      const designSystem = designSystemDoc.data();
+      const brandContext = buildBrandContext(brand, designSystem);
+
+      // 既存のフィードバックを取得
+      const feedbackQuery = await db
+        .collection("creativeFeedbacks")
+        .where("creativeId", "==", creativeId)
+        .where("status", "==", "active")
+        .limit(1)
+        .get();
+
+      let feedbackDoc: FirebaseFirestore.DocumentReference;
+      let existingMessages: any[] = [];
+
+      if (!feedbackQuery.empty) {
+        feedbackDoc = feedbackQuery.docs[0].ref;
+        existingMessages = feedbackQuery.docs[0].data().messages || [];
+      } else {
+        // 新規フィードバックセッションを作成
+        feedbackDoc = db.collection("creativeFeedbacks").doc();
+        await feedbackDoc.set({
+          creativeId,
+          brandId,
+          userId: uid,
+          messages: [],
+          status: "active",
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      }
+
+      // Gemini APIで改善案を生成
+      const model = vertexAI.getGenerativeModel({
+        model: "gemini-2.0-flash",
+        generationConfig: {
+          maxOutputTokens: 2048,
+          temperature: 0.7,
+        },
+      });
+
+      // 会話履歴を構築
+      const conversationHistory = existingMessages
+        .map((msg: any) => {
+          if (msg.role === "user") {
+            return `【ユーザーのフィードバック】\n${msg.content}`;
+          } else {
+            return `【AIの改善案】\n${msg.improvedContent || msg.content}`;
+          }
+        })
+        .join("\n\n");
+
+      const improvementPrompt = `
+あなたはブランドコンサルタント兼クリエイティブディレクターです。
+ユーザーから受け取ったフィードバックに基づいて、クリエイティブの改善案を提示してください。
+
+${brandContext}
+
+【元のクリエイティブ（${creative.type}）】
+${creative.content}
+
+${conversationHistory ? `【これまでの会話履歴】\n${conversationHistory}\n` : ""}
+
+【新しいフィードバック】
+${feedbackText}
+
+【指示】
+1. ユーザーのフィードバックを理解し、具体的な改善案を提示してください
+2. ブランドDNAとの整合性を保ちながら改善してください
+3. 改善案は元のクリエイティブと同じ形式・長さで提示してください
+4. 以下のJSON形式で回答してください:
+
+{
+  "analysis": "フィードバックの分析と改善方針（1〜2文）",
+  "improvedContent": "改善されたクリエイティブの全文"
+}
+
+JSONのみを出力してください。
+`;
+
+      const result = await model.generateContent(improvementPrompt);
+      const responseText =
+        result.response.candidates?.[0]?.content?.parts?.[0]?.text || "";
+
+      const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error("AIからの応答を解析できませんでした");
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]);
+      const analysis = parsed.analysis || "改善案を生成しました。";
+      const improvedContent = parsed.improvedContent || creative.content;
+
+      // メッセージを追加
+      const userMessageId = `msg_${Date.now()}_user`;
+      const assistantMessageId = `msg_${Date.now()}_assistant`;
+
+      const newMessages = [
+        ...existingMessages,
+        {
+          id: userMessageId,
+          role: "user",
+          content: feedbackText,
+          timestamp: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        {
+          id: assistantMessageId,
+          role: "assistant",
+          content: analysis,
+          improvedContent,
+          timestamp: admin.firestore.FieldValue.serverTimestamp(),
+        },
+      ];
+
+      await feedbackDoc.update({
+        messages: newMessages,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      return {
+        success: true,
+        message: "フィードバックを送信しました",
+        feedbackId: feedbackDoc.id,
+        messageId: assistantMessageId,
+        analysis,
+        improvedContent,
+      };
+    } catch (error: any) {
+      console.error("sendCreativeFeedback error:", error);
+      throw new functions.https.HttpsError(
+        "internal",
+        error.message || "フィードバック送信に失敗しました"
+      );
+    }
+  }
+);
+
+/**
+ * 改善案をクリエイティブに適用
+ */
+export const applyCreativeImprovement = functions.https.onCall(
+  {
+    region: LOCATION,
+    cors: true,
+  },
+  async (request) => {
+    const uid = request.auth?.uid;
+    if (!uid) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "認証が必要です"
+      );
+    }
+
+    const { creativeId, messageId } = request.data;
+
+    if (!creativeId || !messageId) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "creativeIdとmessageIdは必須です"
+      );
+    }
+
+    try {
+      // クリエイティブを取得
+      const creativeDoc = await db.collection("creatives").doc(creativeId).get();
+      if (!creativeDoc.exists) {
+        throw new functions.https.HttpsError("not-found", "クリエイティブが見つかりません");
+      }
+
+      const creative = creativeDoc.data();
+      const brandId = creative?.brandId;
+
+      if (!brandId) {
+        throw new functions.https.HttpsError("invalid-argument", "ブランドIDが不正です");
+      }
+
+      // ブランドメンバーシップを検証
+      await verifyBrandMember(brandId, uid);
+
+      // フィードバックを取得
+      const feedbackQuery = await db
+        .collection("creativeFeedbacks")
+        .where("creativeId", "==", creativeId)
+        .where("status", "==", "active")
+        .limit(1)
+        .get();
+
+      if (feedbackQuery.empty) {
+        throw new functions.https.HttpsError("not-found", "フィードバックが見つかりません");
+      }
+
+      const feedbackDoc = feedbackQuery.docs[0];
+      const feedback = feedbackDoc.data();
+      const messages = feedback.messages || [];
+
+      // 対象メッセージを検索
+      const targetMessage = messages.find((msg: any) => msg.id === messageId);
+      if (!targetMessage || targetMessage.role !== "assistant") {
+        throw new functions.https.HttpsError("not-found", "改善案が見つかりません");
+      }
+
+      if (!targetMessage.improvedContent) {
+        throw new functions.https.HttpsError("invalid-argument", "改善内容がありません");
+      }
+
+      // クリエイティブを更新
+      await creativeDoc.ref.update({
+        content: targetMessage.improvedContent,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      // メッセージに適用日時を記録
+      const updatedMessages = messages.map((msg: any) => {
+        if (msg.id === messageId) {
+          return {
+            ...msg,
+            appliedAt: admin.firestore.FieldValue.serverTimestamp(),
+          };
+        }
+        return msg;
+      });
+
+      await feedbackDoc.ref.update({
+        messages: updatedMessages,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      return {
+        success: true,
+        message: "改善案を適用しました",
+      };
+    } catch (error: any) {
+      console.error("applyCreativeImprovement error:", error);
+      throw new functions.https.HttpsError(
+        "internal",
+        error.message || "改善案の適用に失敗しました"
+      );
+    }
+  }
+);
+
+/**
+ * クリエイティブのフィードバック履歴を取得
+ */
+export const getCreativeFeedback = functions.https.onCall(
+  {
+    region: LOCATION,
+    cors: true,
+  },
+  async (request) => {
+    const uid = request.auth?.uid;
+    if (!uid) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "認証が必要です"
+      );
+    }
+
+    const { creativeId } = request.data;
+
+    if (!creativeId) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "creativeIdは必須です"
+      );
+    }
+
+    try {
+      // クリエイティブを取得
+      const creativeDoc = await db.collection("creatives").doc(creativeId).get();
+      if (!creativeDoc.exists) {
+        throw new functions.https.HttpsError("not-found", "クリエイティブが見つかりません");
+      }
+
+      const creative = creativeDoc.data();
+      const brandId = creative?.brandId;
+
+      if (!brandId) {
+        throw new functions.https.HttpsError("invalid-argument", "ブランドIDが不正です");
+      }
+
+      // ブランドメンバーシップを検証
+      await verifyBrandMember(brandId, uid);
+
+      // フィードバックを取得
+      const feedbackQuery = await db
+        .collection("creativeFeedbacks")
+        .where("creativeId", "==", creativeId)
+        .where("status", "==", "active")
+        .limit(1)
+        .get();
+
+      if (feedbackQuery.empty) {
+        return {
+          success: true,
+          feedback: null,
+        };
+      }
+
+      const feedbackDoc = feedbackQuery.docs[0];
+      const feedback = feedbackDoc.data();
+
+      return {
+        success: true,
+        feedback: {
+          id: feedbackDoc.id,
+          ...feedback,
+        },
+      };
+    } catch (error: any) {
+      console.error("getCreativeFeedback error:", error);
+      throw new functions.https.HttpsError(
+        "internal",
+        error.message || "フィードバックの取得に失敗しました"
+      );
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,5 +20,8 @@ export { deleteAccount } from "./account";
 // プレゼンテーション生成関数
 export { generatePresentation } from "./presentations";
 
-// 印刷関連関数（Epson Connect）
+// 印刷関連関数(Epson Connect)
 export { printCreative, saveEpsonSettings, getEpsonSettings } from "./printing";
+
+// フィードバック関連関数
+export { sendCreativeFeedback, applyCreativeImprovement, getCreativeFeedback } from "./feedback";

--- a/src/app/(dashboard)/creatives/page.tsx
+++ b/src/app/(dashboard)/creatives/page.tsx
@@ -56,6 +56,7 @@ import { toast } from "sonner";
 import type { CreativeType, Creative, EpsonPrintSettings } from "@/types";
 import { generateCreativeFunction, generateImageFunction, generatePresentationFunction, printCreativeFunction, getEpsonSettingsFunction } from "@/lib/firebase/functions";
 import { getBrandCreatives, updateCreative } from "@/lib/firebase/firestore";
+import { CreativeFeedbackDialog } from "@/components/features/creative-feedback";
 
 export default function CreativesPage() {
   const searchParams = useSearchParams();
@@ -83,6 +84,8 @@ export default function CreativesPage() {
     color_mode: "color",
     copies: 1,
   });
+  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
+  const [feedbackTarget, setFeedbackTarget] = useState<Creative | null>(null);
 
   useEffect(() => {
     getEpsonSettingsFunction({}).then((res) => {
@@ -235,6 +238,15 @@ export default function CreativesPage() {
       copies: 1,
     });
     setIsPrintOpen(true);
+  };
+
+  const openFeedbackDialog = (creative: Creative) => {
+    setFeedbackTarget(creative);
+    setIsFeedbackOpen(true);
+  };
+
+  const handleFeedbackApplied = async () => {
+    await fetchCreatives();
   };
 
   const copyToClipboard = (text: string) => {
@@ -420,6 +432,15 @@ export default function CreativesPage() {
                 <Printer className="h-4 w-4" />
               </Button>
             )}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-purple-600 hover:bg-purple-500/10"
+              title="フィードバック"
+              onClick={() => openFeedbackDialog(creative)}
+            >
+              <MessageSquare className="h-4 w-4" />
+            </Button>
             <Button
               variant="ghost"
               size="icon"
@@ -966,6 +987,16 @@ export default function CreativesPage() {
             )
           )}
         </Tabs>
+      )}
+
+      {/* フィードバックダイアログ */}
+      {feedbackTarget && (
+        <CreativeFeedbackDialog
+          creative={feedbackTarget}
+          open={isFeedbackOpen}
+          onOpenChange={setIsFeedbackOpen}
+          onApplied={handleFeedbackApplied}
+        />
       )}
     </div>
   );

--- a/src/components/features/creative-feedback/creative-feedback-dialog.tsx
+++ b/src/components/features/creative-feedback/creative-feedback-dialog.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  MessageSquare,
+  Send,
+  Sparkles,
+  Check,
+  Clock,
+  User,
+  Bot,
+} from "lucide-react";
+import { toast } from "sonner";
+import type { Creative, CreativeFeedback, FeedbackMessage } from "@/types";
+import {
+  sendCreativeFeedbackFunction,
+  applyCreativeImprovementFunction,
+  getCreativeFeedbackFunction,
+} from "@/lib/firebase/functions";
+
+interface CreativeFeedbackDialogProps {
+  creative: Creative;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onApplied?: () => void;
+}
+
+export function CreativeFeedbackDialog({
+  creative,
+  open,
+  onOpenChange,
+  onApplied,
+}: CreativeFeedbackDialogProps) {
+  const [feedback, setFeedback] = useState<CreativeFeedback | null>(null);
+  const [feedbackText, setFeedbackText] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [isApplying, setIsApplying] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      loadFeedback();
+    }
+  }, [open, creative.id]);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [feedback?.messages]);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  const loadFeedback = async () => {
+    setIsLoading(true);
+    try {
+      const result = await getCreativeFeedbackFunction({
+        creativeId: creative.id,
+      });
+      if (result.data.success && result.data.feedback) {
+        setFeedback(result.data.feedback);
+      } else {
+        setFeedback(null);
+      }
+    } catch (error: any) {
+      console.error("Failed to load feedback:", error);
+      toast.error("フィードバック履歴の読み込みに失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSendFeedback = async () => {
+    if (!feedbackText.trim()) return;
+
+    setIsSending(true);
+    try {
+      const result = await sendCreativeFeedbackFunction({
+        creativeId: creative.id,
+        feedbackText: feedbackText.trim(),
+      });
+
+      if (result.data.success) {
+        toast.success("フィードバックを送信しました");
+        setFeedbackText("");
+        await loadFeedback();
+      } else {
+        toast.error("フィードバックの送信に失敗しました");
+      }
+    } catch (error: any) {
+      console.error("Failed to send feedback:", error);
+      toast.error(error.message || "フィードバックの送信に失敗しました");
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleApplyImprovement = async (messageId: string) => {
+    setIsApplying(messageId);
+    try {
+      const result = await applyCreativeImprovementFunction({
+        creativeId: creative.id,
+        messageId,
+      });
+
+      if (result.data.success) {
+        toast.success("改善案を適用しました");
+        await loadFeedback();
+        onApplied?.();
+      } else {
+        toast.error("改善案の適用に失敗しました");
+      }
+    } catch (error: any) {
+      console.error("Failed to apply improvement:", error);
+      toast.error(error.message || "改善案の適用に失敗しました");
+    } finally {
+      setIsApplying(null);
+    }
+  };
+
+  const formatTimestamp = (timestamp: any) => {
+    if (!timestamp) return "";
+    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
+    return date.toLocaleTimeString("ja-JP", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  const getTypeLabel = (type: string) => {
+    switch (type) {
+      case "CATCH_COPY":
+        return "キャッチコピー";
+      case "SNS_POST":
+        return "SNS投稿";
+      case "ARTICLE":
+        return "記事";
+      case "IMAGE":
+        return "画像";
+      case "PRESENTATION":
+        return "プレゼン";
+      default:
+        return type;
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-6xl h-[85vh] flex flex-col p-0">
+        <DialogHeader className="px-6 py-4 border-b">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10">
+              <MessageSquare className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <DialogTitle className="text-xl">
+                クリエイティブフィードバック
+              </DialogTitle>
+              <DialogDescription>
+                AIと対話しながらクリエイティブを改善できます
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 flex overflow-hidden">
+          {/* 左側: 元のクリエイティブ */}
+          <div className="w-1/2 border-r flex flex-col">
+            <div className="px-6 py-3 border-b bg-muted/30">
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">{getTypeLabel(creative.type)}</Badge>
+                <span className="text-sm font-semibold text-muted-foreground">
+                  元のクリエイティブ
+                </span>
+              </div>
+            </div>
+            <div className="flex-1 overflow-y-auto p-6">
+              {creative.type === "IMAGE" && creative.imageUrl && (
+                <div className="mb-4 rounded-xl overflow-hidden border">
+                  <img
+                    src={creative.imageUrl}
+                    alt="Generated image"
+                    className="w-full h-auto"
+                  />
+                </div>
+              )}
+              <div className="rounded-xl bg-muted/20 border p-5">
+                <pre className="whitespace-pre-wrap text-sm font-sans leading-relaxed">
+                  {creative.content}
+                </pre>
+              </div>
+              {creative.prompt && (
+                <div className="mt-4 text-xs text-muted-foreground">
+                  <span className="font-semibold">テーマ:</span> {creative.prompt}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 右側: フィードバックチャット */}
+          <div className="w-1/2 flex flex-col">
+            <div className="px-6 py-3 border-b bg-muted/30">
+              <div className="flex items-center gap-2">
+                <Sparkles className="h-4 w-4 text-primary" />
+                <span className="text-sm font-semibold text-muted-foreground">
+                  フィードバック履歴
+                </span>
+              </div>
+            </div>
+
+            {/* メッセージエリア */}
+            <div className="flex-1 overflow-y-auto p-6 space-y-4">
+              {isLoading ? (
+                <div className="space-y-4">
+                  {[1, 2].map((i) => (
+                    <div key={i} className="space-y-2">
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-20 w-full" />
+                    </div>
+                  ))}
+                </div>
+              ) : feedback?.messages && feedback.messages.length > 0 ? (
+                feedback.messages.map((message: FeedbackMessage) => (
+                  <div key={message.id} className="space-y-2">
+                    {message.role === "user" ? (
+                      <div className="flex items-start gap-3">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 flex-shrink-0">
+                          <User className="h-4 w-4 text-primary" />
+                        </div>
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-xs font-semibold">あなた</span>
+                            <span className="text-xs text-muted-foreground">
+                              {formatTimestamp(message.timestamp)}
+                            </span>
+                          </div>
+                          <div className="rounded-xl bg-primary/5 border border-primary/20 p-4">
+                            <p className="text-sm whitespace-pre-wrap">
+                              {message.content}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-start gap-3">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-purple-500/10 flex-shrink-0">
+                          <Bot className="h-4 w-4 text-purple-600" />
+                        </div>
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-xs font-semibold text-purple-600">
+                              AI
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              {formatTimestamp(message.timestamp)}
+                            </span>
+                            {message.appliedAt && (
+                              <Badge
+                                variant="outline"
+                                className="text-xs bg-emerald-500/10 text-emerald-600 border-emerald-200"
+                              >
+                                <Check className="mr-1 h-3 w-3" />
+                                適用済み
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="space-y-3">
+                            <div className="rounded-xl bg-purple-500/5 border border-purple-200/50 p-4">
+                              <p className="text-sm text-muted-foreground mb-2">
+                                {message.content}
+                              </p>
+                              {message.improvedContent && (
+                                <>
+                                  <div className="mt-3 pt-3 border-t border-purple-200/50">
+                                    <p className="text-xs font-semibold text-purple-600 mb-2">
+                                      改善案:
+                                    </p>
+                                    <pre className="text-sm whitespace-pre-wrap font-sans leading-relaxed">
+                                      {message.improvedContent}
+                                    </pre>
+                                  </div>
+                                  {!message.appliedAt && (
+                                    <Button
+                                      size="sm"
+                                      className="mt-3 w-full"
+                                      onClick={() =>
+                                        handleApplyImprovement(message.id)
+                                      }
+                                      disabled={isApplying === message.id}
+                                    >
+                                      {isApplying === message.id ? (
+                                        <>
+                                          <Clock className="mr-2 h-3 w-3 animate-spin" />
+                                          適用中...
+                                        </>
+                                      ) : (
+                                        <>
+                                          <Check className="mr-2 h-3 w-3" />
+                                          この改善を適用
+                                        </>
+                                      )}
+                                    </Button>
+                                  )}
+                                </>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))
+              ) : (
+                <div className="flex flex-col items-center justify-center h-full text-center">
+                  <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-muted/50 mb-4">
+                    <MessageSquare className="h-8 w-8 text-muted-foreground/40" />
+                  </div>
+                  <h3 className="text-sm font-semibold mb-2">
+                    フィードバックがありません
+                  </h3>
+                  <p className="text-xs text-muted-foreground max-w-xs">
+                    下のフォームからフィードバックを送信すると、AIが改善案を提示します
+                  </p>
+                </div>
+              )}
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* 入力エリア */}
+            <div className="border-t p-4 bg-muted/20">
+              <div className="space-y-3">
+                <Textarea
+                  placeholder="改善してほしい点を入力してください（例: もっとカジュアルなトーンにしてほしい、具体例を追加してほしい）"
+                  value={feedbackText}
+                  onChange={(e) => setFeedbackText(e.target.value)}
+                  className="min-h-[80px] resize-none"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                      e.preventDefault();
+                      handleSendFeedback();
+                    }
+                  }}
+                />
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">
+                    Cmd/Ctrl + Enter で送信
+                  </span>
+                  <Button
+                    onClick={handleSendFeedback}
+                    disabled={!feedbackText.trim() || isSending}
+                  >
+                    {isSending ? (
+                      <>
+                        <Clock className="mr-2 h-4 w-4 animate-spin" />
+                        送信中...
+                      </>
+                    ) : (
+                      <>
+                        <Send className="mr-2 h-4 w-4" />
+                        フィードバックを送信
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/features/creative-feedback/index.ts
+++ b/src/components/features/creative-feedback/index.ts
@@ -1,0 +1,1 @@
+export { CreativeFeedbackDialog } from "./creative-feedback-dialog";

--- a/src/lib/firebase/functions.ts
+++ b/src/lib/firebase/functions.ts
@@ -176,3 +176,42 @@ export const getEpsonSettingsFunction = httpsCallable<
     connectionStatus?: string;
   }
 >(functions, "getEpsonSettings");
+
+// クリエイティブフィードバック送信
+export const sendCreativeFeedbackFunction = httpsCallable<
+  {
+    creativeId: string;
+    feedbackText: string;
+  },
+  {
+    success: boolean;
+    message?: string;
+    feedbackId?: string;
+    messageId?: string;
+    analysis?: string;
+    improvedContent?: string;
+  }
+>(functions, "sendCreativeFeedback");
+
+// クリエイティブ改善案適用
+export const applyCreativeImprovementFunction = httpsCallable<
+  {
+    creativeId: string;
+    messageId: string;
+  },
+  {
+    success: boolean;
+    message?: string;
+  }
+>(functions, "applyCreativeImprovement");
+
+// クリエイティブフィードバック取得
+export const getCreativeFeedbackFunction = httpsCallable<
+  {
+    creativeId: string;
+  },
+  {
+    success: boolean;
+    feedback?: import("@/types").CreativeFeedback | null;
+  }
+>(functions, "getCreativeFeedback");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -193,3 +193,34 @@ export interface EpsonConnectSettings {
   printerName?: string;
   connectionStatus?: string;
 }
+
+// Creative Feedback
+export interface FeedbackMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Timestamp;
+  improvedContent?: string;
+  appliedAt?: Timestamp;
+}
+
+export interface CreativeFeedback {
+  id: string;
+  creativeId: string;
+  brandId: string;
+  userId: string;
+  messages: FeedbackMessage[];
+  status: "active" | "resolved";
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface SendCreativeFeedbackRequest {
+  creativeId: string;
+  feedbackText: string;
+}
+
+export interface ApplyCreativeImprovementRequest {
+  creativeId: string;
+  messageId: string;
+}


### PR DESCRIPTION
- チャット形式でクリエイティブに対してフィードバックを送信できる機能を実装
- AIが改善案を生成し、ワンクリックで適用可能
- フィードバック履歴をFirestoreに保存
- Cloud Functions: sendCreativeFeedback, applyCreativeImprovement, getCreativeFeedback
- UIコンポーネント: CreativeFeedbackDialog
- Firestore Rules: creativeFeedbacksコレクションのアクセス制御を追加