### PR TITLE
feat: Add content feedback feature with text selection and flagging

### DIFF
--- a/src/app/(dashboard)/creatives/page.tsx
+++ b/src/app/(dashboard)/creatives/page.tsx
@@ -53,9 +53,10 @@ import {
   Presentation,
 } from "lucide-react";
 import { toast } from "sonner";
-import type { CreativeType, Creative, EpsonPrintSettings } from "@/types";
+import type { CreativeType, Creative, EpsonPrintSettings, ContentFeedback } from "@/types";
 import { generateCreativeFunction, generateImageFunction, generatePresentationFunction, printCreativeFunction, getEpsonSettingsFunction } from "@/lib/firebase/functions";
-import { getBrandCreatives, updateCreative } from "@/lib/firebase/firestore";
+import { getBrandCreatives, updateCreative, addContentFeedback, updateContentFeedback, removeContentFeedback } from "@/lib/firebase/firestore";
+import { ContentFeedbackHighlight } from "@/components/features/content-feedback/ContentFeedbackHighlight";
 
 export default function CreativesPage() {
   const searchParams = useSearchParams();
@@ -481,11 +482,43 @@ export default function CreativesPage() {
           )}
 
           {/* コンテンツ表示 */}
-          <div className="rounded-xl bg-muted/20 border border-border/30 p-5">
-            <pre className="whitespace-pre-wrap text-sm text-foreground font-sans leading-relaxed">
-              {creative.content}
-            </pre>
-          </div>
+          <ContentFeedbackHighlight
+            content={creative.content}
+            feedbacks={creative.feedbacks || []}
+            onAddFeedback={async (feedback) => {
+              try {
+                await addContentFeedback(creative.id, {
+                  ...feedback,
+                  createdBy: firebaseUser?.uid || "",
+                });
+                await loadCreatives();
+                toast.success("フィードバックを追加しました");
+              } catch (error) {
+                console.error("Failed to add feedback:", error);
+                toast.error("フィードバックの追加に失敗しました");
+              }
+            }}
+            onUpdateFeedback={async (feedbackId, updates) => {
+              try {
+                await updateContentFeedback(creative.id, feedbackId, updates);
+                await loadCreatives();
+                toast.success("フィードバックを更新しました");
+              } catch (error) {
+                console.error("Failed to update feedback:", error);
+                toast.error("フィードバックの更新に失敗しました");
+              }
+            }}
+            onRemoveFeedback={async (feedbackId) => {
+              try {
+                await removeContentFeedback(creative.id, feedbackId);
+                await loadCreatives();
+                toast.success("フィードバックを削除しました");
+              } catch (error) {
+                console.error("Failed to remove feedback:", error);
+                toast.error("フィードバックの削除に失敗しました");
+              }
+            }}
+          />
 
           {/* メタ情報 */}
           <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">

--- a/src/components/features/content-feedback/ContentFeedbackHighlight.tsx
+++ b/src/components/features/content-feedback/ContentFeedbackHighlight.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Button } from "@/components/ui/button";
+
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Check, Edit, X, MessageSquare, Trash2 } from "lucide-react";
+import type { ContentFeedback, FeedbackFlag } from "@/types";
+
+interface ContentFeedbackHighlightProps {
+  content: string;
+  feedbacks: ContentFeedback[];
+  onAddFeedback: (feedback: Omit<ContentFeedback, "id" | "createdAt" | "createdBy">) => Promise<void>;
+  onUpdateFeedback: (feedbackId: string, updates: Partial<Pick<ContentFeedback, "flag" | "note">>) => Promise<void>;
+  onRemoveFeedback: (feedbackId: string) => Promise<void>;
+  readOnly?: boolean;
+}
+
+export function ContentFeedbackHighlight({
+  content,
+  feedbacks,
+  onAddFeedback,
+  onUpdateFeedback,
+  onRemoveFeedback,
+  readOnly = false,
+}: ContentFeedbackHighlightProps) {
+  const [selection, setSelection] = useState<{
+    text: string;
+    start: number;
+    end: number;
+  } | null>(null);
+  const [showPopover, setShowPopover] = useState(false);
+  const [popoverPosition, setPopoverPosition] = useState({ x: 0, y: 0 });
+  const [selectedFeedback, setSelectedFeedback] = useState<ContentFeedback | null>(null);
+  const [editingNote, setEditingNote] = useState<string>("");
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleTextSelection = () => {
+    if (readOnly) return;
+
+    const selectedText = window.getSelection()?.toString();
+    if (!selectedText || selectedText.trim().length === 0) {
+      setShowPopover(false);
+      return;
+    }
+
+    const range = window.getSelection()?.getRangeAt(0);
+    if (!range) return;
+
+    const preSelectionRange = range.cloneRange();
+    preSelectionRange.selectNodeContents(contentRef.current!);
+    preSelectionRange.setEnd(range.startContainer, range.startOffset);
+    const start = preSelectionRange.toString().length;
+    const end = start + selectedText.length;
+
+    setSelection({ text: selectedText, start, end });
+
+    const rect = range.getBoundingClientRect();
+    setPopoverPosition({
+      x: rect.left + rect.width / 2,
+      y: rect.top - 10,
+    });
+    setShowPopover(true);
+  };
+
+  const addFeedback = async (flag: FeedbackFlag, note?: string) => {
+    if (!selection) return;
+
+    await onAddFeedback({
+      startIndex: selection.start,
+      endIndex: selection.end,
+      selectedText: selection.text,
+      flag,
+      note,
+    });
+
+    setSelection(null);
+    setShowPopover(false);
+    window.getSelection()?.removeAllRanges();
+  };
+
+  const getFlagColor = (flag: FeedbackFlag) => {
+    switch (flag) {
+      case "approved":
+        return "bg-emerald-100 text-emerald-700 border-emerald-300";
+      case "needs_revision":
+        return "bg-yellow-100 text-yellow-700 border-yellow-300";
+      case "rejected":
+        return "bg-red-100 text-red-700 border-red-300";
+    }
+  };
+
+  const getFlagLabel = (flag: FeedbackFlag) => {
+    switch (flag) {
+      case "approved":
+        return "採用";
+      case "needs_revision":
+        return "要修正";
+      case "rejected":
+        return "却下";
+    }
+  };
+
+  const renderHighlightedContent = () => {
+    if (feedbacks.length === 0) {
+      return <span>{content}</span>;
+    }
+
+    const sortedFeedbacks = [...feedbacks].sort((a, b) => a.startIndex - b.startIndex);
+    const segments: JSX.Element[] = [];
+    let currentIndex = 0;
+
+    sortedFeedbacks.forEach((feedback, idx) => {
+      if (currentIndex < feedback.startIndex) {
+        segments.push(
+          <span key={`text-${idx}`}>{content.slice(currentIndex, feedback.startIndex)}</span>
+        );
+      }
+
+      segments.push(
+        <span
+          key={`feedback-${feedback.id}`}
+          className={`relative cursor-pointer rounded px-1 ${getFlagColor(feedback.flag)}`}
+          onClick={() => {
+            setSelectedFeedback(feedback);
+            setEditingNote(feedback.note || "");
+          }}
+        >
+          {content.slice(feedback.startIndex, feedback.endIndex)}
+        </span>
+      );
+
+      currentIndex = feedback.endIndex;
+    });
+
+    if (currentIndex < content.length) {
+      segments.push(<span key="text-end">{content.slice(currentIndex)}</span>);
+    }
+
+    return <>{segments}</>;
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        ref={contentRef}
+        className="rounded-xl bg-muted/20 border border-border/30 p-5 relative select-text"
+        onMouseUp={handleTextSelection}
+      >
+        <pre className="whitespace-pre-wrap text-sm text-foreground font-sans leading-relaxed">
+          {renderHighlightedContent()}
+        </pre>
+      </div>
+
+      {/* Selection Popover */}
+      {showPopover && selection && (
+        <div
+          className="fixed z-50"
+          style={{
+            left: `${popoverPosition.x}px`,
+            top: `${popoverPosition.y}px`,
+            transform: "translate(-50%, -100%)",
+          }}
+        >
+          <div className="bg-white rounded-lg shadow-lg border border-border p-2 flex gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8 text-emerald-600 hover:bg-emerald-50"
+              onClick={() => addFeedback("approved")}
+            >
+              <Check className="h-4 w-4 mr-1" />
+              採用
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8 text-yellow-600 hover:bg-yellow-50"
+              onClick={() => addFeedback("needs_revision")}
+            >
+              <Edit className="h-4 w-4 mr-1" />
+              要修正
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8 text-red-600 hover:bg-red-50"
+              onClick={() => addFeedback("rejected")}
+            >
+              <X className="h-4 w-4 mr-1" />
+              却下
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8"
+              onClick={() => setShowPopover(false)}
+            >
+              キャンセル
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Feedback Detail Dialog */}
+      {selectedFeedback && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl p-6 max-w-md w-full mx-4">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold">フィードバック詳細</h3>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={() => setSelectedFeedback(null)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">選択テキスト</label>
+                <p className="mt-1 text-sm bg-muted/50 p-2 rounded">
+                  {selectedFeedback.selectedText}
+                </p>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">ステータス</label>
+                <div className="mt-2 flex gap-2">
+                  {(["approved", "needs_revision", "rejected"] as FeedbackFlag[]).map((flag) => (
+                    <Button
+                      key={flag}
+                      size="sm"
+                      variant={selectedFeedback.flag === flag ? "default" : "outline"}
+                      onClick={() => onUpdateFeedback(selectedFeedback.id, { flag })}
+                      disabled={readOnly}
+                    >
+                      {getFlagLabel(flag)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">メモ</label>
+                <Textarea
+                  className="mt-1"
+                  placeholder="メモを入力..."
+                  value={editingNote}
+                  onChange={(e) => setEditingNote(e.target.value)}
+                  disabled={readOnly}
+                />
+              </div>
+
+              <div className="flex gap-2">
+                <Button
+                  className="flex-1"
+                  onClick={() => {
+                    onUpdateFeedback(selectedFeedback.id, { note: editingNote });
+                    setSelectedFeedback(null);
+                  }}
+                  disabled={readOnly}
+                >
+                  <MessageSquare className="h-4 w-4 mr-2" />
+                  保存
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => {
+                    onRemoveFeedback(selectedFeedback.id);
+                    setSelectedFeedback(null);
+                  }}
+                  disabled={readOnly}
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  削除
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Feedback Summary */}
+      {feedbacks.length > 0 && (
+        <div className="rounded-lg border border-border/50 p-4 bg-accent/50">
+          <h4 className="text-sm font-semibold mb-3">フィードバックサマリー</h4>
+          <div className="flex gap-2 flex-wrap">
+            <Badge variant="outline" className="bg-emerald-50 text-emerald-700 border-emerald-300">
+              <Check className="h-3 w-3 mr-1" />
+              採用: {feedbacks.filter((f) => f.flag === "approved").length}
+            </Badge>
+            <Badge variant="outline" className="bg-yellow-50 text-yellow-700 border-yellow-300">
+              <Edit className="h-3 w-3 mr-1" />
+              要修正: {feedbacks.filter((f) => f.flag === "needs_revision").length}
+            </Badge>
+            <Badge variant="outline" className="bg-red-50 text-red-700 border-red-300">
+              <X className="h-3 w-3 mr-1" />
+              却下: {feedbacks.filter((f) => f.flag === "rejected").length}
+            </Badge>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -20,6 +20,7 @@ import type {
   Asset,
   DesignSystem,
   Creative,
+  ContentFeedback,
   BrandRole,
 } from "@/types";
 
@@ -326,6 +327,61 @@ export async function updateCreative(
 
 export async function deleteCreative(creativeId: string): Promise<void> {
   await deleteDoc(doc(checkDbInit(), "creatives", creativeId));
+}
+
+export async function addContentFeedback(
+  creativeId: string,
+  feedback: Omit<ContentFeedback, "id" | "createdAt">
+): Promise<void> {
+  const creative = await getCreative(creativeId);
+  if (!creative) throw new Error("Creative not found");
+
+  const newFeedback: ContentFeedback = {
+    ...feedback,
+    id: `fb_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+    createdAt: serverTimestamp() as Timestamp,
+  };
+
+  const feedbacks = creative.feedbacks || [];
+  feedbacks.push(newFeedback);
+
+  await updateDoc(doc(checkDbInit(), "creatives", creativeId), {
+    feedbacks,
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export async function removeContentFeedback(
+  creativeId: string,
+  feedbackId: string
+): Promise<void> {
+  const creative = await getCreative(creativeId);
+  if (!creative) throw new Error("Creative not found");
+
+  const feedbacks = (creative.feedbacks || []).filter((fb) => fb.id !== feedbackId);
+
+  await updateDoc(doc(checkDbInit(), "creatives", creativeId), {
+    feedbacks,
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export async function updateContentFeedback(
+  creativeId: string,
+  feedbackId: string,
+  updates: Partial<Pick<ContentFeedback, "flag" | "note">>
+): Promise<void> {
+  const creative = await getCreative(creativeId);
+  if (!creative) throw new Error("Creative not found");
+
+  const feedbacks = (creative.feedbacks || []).map((fb) =>
+    fb.id === feedbackId ? { ...fb, ...updates } : fb
+  );
+
+  await updateDoc(doc(checkDbInit(), "creatives", creativeId), {
+    feedbacks,
+    updatedAt: serverTimestamp(),
+  });
 }
 
 export async function getAllUserAssets(brandIds: string[]): Promise<Asset[]> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,8 @@ export type CreativeType = "CATCH_COPY" | "SNS_POST" | "ARTICLE" | "IMAGE" | "PR
 
 export type CreativeStatus = "DRAFT" | "PUBLISHED" | "ARCHIVED";
 
+export type FeedbackFlag = "approved" | "needs_revision" | "rejected";
+
 export interface User {
   id: string;
   email: string;
@@ -107,6 +109,17 @@ export interface CreativeMetadata {
   generationTime?: number;
 }
 
+export interface ContentFeedback {
+  id: string;
+  startIndex: number;
+  endIndex: number;
+  selectedText: string;
+  flag: FeedbackFlag;
+  note?: string;
+  createdAt: Timestamp;
+  createdBy: string;
+}
+
 export interface Creative {
   id: string;
   brandId: string;
@@ -116,6 +129,7 @@ export interface Creative {
   imageUrl?: string;
   pptxUrl?: string;
   metadata: CreativeMetadata;
+  feedbacks?: ContentFeedback[];
   isFavorite?: boolean;
   createdBy: string;
   createdAt: Timestamp;


### PR DESCRIPTION
## 概要

生成コンテンツに対するフィードバック機能を実装しました。テキストの部分選択とフラグ付けにより、生成されたコンテンツの評価と管理が可能になります。

## 機能

### 1. テキスト選択とフラグ付け
- 生成されたテキストコンテンツの任意の部分を選択
- 選択した部分に対して以下のフラグを付与:
  - **採用** (approved): 緑色でハイライト
  - **要修正** (needs_revision): 黄色でハイライト
  - **却下** (rejected): 赤色でハイライト

### 2. フィードバック管理
- ハイライトされた部分をクリックして詳細表示
- フラグの変更
- メモの追加・編集
- フィードバックの削除

### 3. フィードバックサマリー
- 各フラグの数を集計して表示
- 視覚的にフィードバック状況を把握

## 実装内容

### データモデル

**ContentFeedback インターフェース**:
```typescript
interface ContentFeedback {
  id: string;
  startIndex: number;  // 選択開始位置
  endIndex: number;    // 選択終了位置
  selectedText: string; // 選択されたテキスト
  flag: FeedbackFlag;  // approved | needs_revision | rejected
  note?: string;       // メモ
  createdAt: Timestamp;
  createdBy: string;
}
```

**Creative インターフェースの拡張**:
```typescript
interface Creative {
  // ... 既存フィールド
  feedbacks?: ContentFeedback[];
}
```

### バックエンド (Firestore)

- `addContentFeedback()`: フィードバックを追加
- `updateContentFeedback()`: フィードバックを更新
- `removeContentFeedback()`: フィードバックを削除

### フロントエンド

**ContentFeedbackHighlight コンポーネント**:
- テキスト選択時にポップアップメニューを表示
- フラグ付けボタン(採用/要修正/却下)
- ハイライト表示とクリックで詳細ダイアログ
- フィードバックサマリーパネル

**統合**:
- `/creatives` ページに統合
- 既存のコンテンツ表示部分を `ContentFeedbackHighlight` に置き換え

## 変更ファイル

- `src/types/index.ts`: 型定義の追加
- `src/lib/firebase/firestore.ts`: バックエンド関数の実装
- `src/components/features/content-feedback/ContentFeedbackHighlight.tsx`: UIコンポーネント
- `src/app/(dashboard)/creatives/page.tsx`: 統合

## 使用方法

1. クリエイティブページでコンテンツを表示
2. テキストをマウスで選択
3. ポップアップメニューから「採用」「要修正」「却下」を選択
4. ハイライトされた部分をクリックして詳細を確認・編集
5. フィードバックサマリーで全体の状況を確認

## スクリーンショット

(実際の使用時にスクリーンショットを追加してください)

## テスト

- コードレビュー完了
- 型チェック完了
- 構文エラーなし

## 今後の改善案

- フィードバックのエクスポート機能
- フィードバックに基づく自動再生成
- チームメンバー間でのフィードバック共有
- フィードバック履歴の表示